### PR TITLE
Fix: Improve list resizing consistency for better UX

### DIFF
--- a/style.css
+++ b/style.css
@@ -14,6 +14,7 @@ html > body .stqrs--root .stqrs--wrapper {
 html > body .stqrs--root .stqrs--sets {
   overflow: auto;
   margin: 0;
+  width: 250px;
 }
 html > body .stqrs--root .stqrs--sets .stqrs--set {
   display: flex;
@@ -31,6 +32,9 @@ html > body .stqrs--root .stqrs--sets .stqrs--set .stqrs--toggle.stqrs--active {
 html > body .stqrs--root .stqrs--qrs {
   overflow: auto;
   margin: 0;
+  position: absolute;
+  bottom: 0;
+  left: 250px;
 }
 html > body .stqrs--root .stqrs--qrs .stqrs--qr {
   display: flex;


### PR DESCRIPTION
This pull request addresses an issue where large differences in sets of quick replies would cause continuous resizing of the UI. This resizing made it difficult to interact with the extension.

The changes in this PR prevent this constant resizing, leading to a more stable and usable interface when handling a variety of quick reply sets.